### PR TITLE
Bump ac-cloudifier app to release version.

### DIFF
--- a/meta-aesd/conf/distro/ac-cloudifier.conf
+++ b/meta-aesd/conf/distro/ac-cloudifier.conf
@@ -14,5 +14,5 @@ VIRTUAL-RUNTIME_initscripts = ""
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 LICENSE_FLAGS_ACCEPTED += "commercial"
 
-# add 500 megabytes at the end for development
-IMAGE_ROOTFS_EXTRA_SPACE:append = " + 500000"
+# add 100 megabytes at the end for development
+IMAGE_ROOTFS_EXTRA_SPACE:append = " + 100000"

--- a/meta-aesd/conf/distro/ac-cloudifier.conf
+++ b/meta-aesd/conf/distro/ac-cloudifier.conf
@@ -12,6 +12,7 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+LICENSE_FLAGS_ACCEPTED += "commercial"
 
 # add 500 megabytes at the end for development
 IMAGE_ROOTFS_EXTRA_SPACE:append = " + 500000"

--- a/meta-aesd/conf/machine/raspberrypi0-2w-64.conf
+++ b/meta-aesd/conf/machine/raspberrypi0-2w-64.conf
@@ -1,4 +1,7 @@
 
+PACKAGECONFIG:remove:pn-rpidistro-ffmpeg = "epoxy"
+PACKAGECONFIG:remove:pn-rpidistro-ffmpeg = "vout-egl"
+
 ### SETTINGS FOR meta-raspberrypi BOARD SUPPORT PACKAGE ###
 # Enable video camera
 VIDEO_CAMERA = "1"

--- a/meta-aesd/recipes-aesd-assignments/acc-control/acc-control_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-control/acc-control_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "pigpio lirc mosquitto"
 
 SRC_URI = "git://git@github.com/IvanVeloz/ac-cloudifier;protocol=ssh;branch=main"
 PV = "1.0+git${SRCPV}"
-SRCREV = "62a79b702b23d2c04d8921be0bf7f2a5e21f231a"
+SRCREV = "1c540703420acaba0c8edba29be2d3b8ea22d3f6"
 
 S = "${WORKDIR}/git/acc-control"
 

--- a/meta-aesd/recipes-aesd-assignments/acc-control/acc-control_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-control/acc-control_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "pigpio lirc mosquitto"
 
 SRC_URI = "git://git@github.com/IvanVeloz/ac-cloudifier;protocol=ssh;branch=main"
 PV = "1.0+git${SRCPV}"
-SRCREV = "2a30454ca7a5a08ffe50c7e695358048aa31fd41"
+SRCREV = "62a79b702b23d2c04d8921be0bf7f2a5e21f231a"
 
 S = "${WORKDIR}/git/acc-control"
 

--- a/meta-aesd/recipes-aesd-assignments/acc-control/acc-control_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-control/acc-control_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "pigpio lirc mosquitto"
 
 SRC_URI = "git://git@github.com/IvanVeloz/ac-cloudifier;protocol=ssh;branch=main"
 PV = "1.0+git${SRCPV}"
-SRCREV = "90a6a9a92b997170f73d43d6e909c2a2f39038c1"
+SRCREV = "2a30454ca7a5a08ffe50c7e695358048aa31fd41"
 
 S = "${WORKDIR}/git/acc-control"
 

--- a/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
@@ -11,7 +11,7 @@ SRCREV = "2a30454ca7a5a08ffe50c7e695358048aa31fd41"
 S = "${WORKDIR}/git/acc-machvis"
 
 RDEPENDS: += "${PYTHON_PN} ${PYTHON_PN}-numpy ${PYTHON_PN}-opencv"
-RDEPENDS: += "opencv"
+RDEPENDS: += "opencv libcamera libcamera-apps"
 
 do_install:append() {
     install -d ${D}${bindir}

--- a/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
@@ -6,10 +6,17 @@ DEPENDS += "${PYTHON_PN} ${PYTHON_PN}-pip"
 
 SRC_URI = "git://git@github.com/IvanVeloz/ac-cloudifier;protocol=ssh;branch=main"
 PV = "1.0+git${SRCPV}"
-SRCREV = "90a6a9a92b997170f73d43d6e909c2a2f39038c1"
+SRCREV = "2a30454ca7a5a08ffe50c7e695358048aa31fd41"
 
 S = "${WORKDIR}/git/acc-machvis"
 
-RDEPENDS: += "${PYTHON_PN} ${PYTHON_PN}-numpy ${PYTHON_PN}-opencv" 
+RDEPENDS: += "${PYTHON_PN} ${PYTHON_PN}-numpy ${PYTHON_PN}-opencv"
+RDEPENDS: += "opencv"
+
+do_install:append() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/utils/deviceside/acc-vid.sh ${D}${bindir}
+}
+
 
 inherit setuptools3

--- a/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "${PYTHON_PN} ${PYTHON_PN}-pip"
 
 SRC_URI = "git://git@github.com/IvanVeloz/ac-cloudifier;protocol=ssh;branch=main"
 PV = "1.0+git${SRCPV}"
-SRCREV = "2a30454ca7a5a08ffe50c7e695358048aa31fd41"
+SRCREV = "62a79b702b23d2c04d8921be0bf7f2a5e21f231a"
 
 S = "${WORKDIR}/git/acc-machvis"
 

--- a/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/acc-machvis/acc-machvis_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "${PYTHON_PN} ${PYTHON_PN}-pip"
 
 SRC_URI = "git://git@github.com/IvanVeloz/ac-cloudifier;protocol=ssh;branch=main"
 PV = "1.0+git${SRCPV}"
-SRCREV = "62a79b702b23d2c04d8921be0bf7f2a5e21f231a"
+SRCREV = "1c540703420acaba0c8edba29be2d3b8ea22d3f6"
 
 S = "${WORKDIR}/git/acc-machvis"
 

--- a/meta-aesd/recipes-aesd-assignments/images/core-image-aesd.bb
+++ b/meta-aesd/recipes-aesd-assignments/images/core-image-aesd.bb
@@ -10,6 +10,7 @@ CORE_IMAGE_EXTRA_INSTALL += "ntp"
 # For comfort
 CORE_IMAGE_EXTRA_INSTALL += "tmux mosh"
 CORE_IMAGE_EXTRA_INSTALL += "nano"
+CORE_IMAGE_EXTRA_INSTALL += "htop"
 
 # ac-cloudifier application
 CORE_IMAGE_EXTRA_INSTALL += "acc-control"

--- a/meta-aesd/recipes-aesd-assignments/images/core-image-aesd.bb
+++ b/meta-aesd/recipes-aesd-assignments/images/core-image-aesd.bb
@@ -13,6 +13,7 @@ CORE_IMAGE_EXTRA_INSTALL += "nano"
 
 # ac-cloudifier application
 CORE_IMAGE_EXTRA_INSTALL += "acc-control"
+CORE_IMAGE_EXTRA_INSTALL += "acc-machvis"
 
 # ac-cloudifier-demo
 CORE_IMAGE_EXTRA_INSTALL += "lircdemo"
@@ -29,8 +30,7 @@ CORE_IMAGE_EXTRA_INSTALL += "libcamera libcamera-apps"
 CORE_IMAGE_EXTRA_INSTALL += "pigpio-bin-pigs"
 
 # adding python3-opencv and v4l-utils for opencv testing through the command line
-PACKAGECONFIG:pn-opencv += "python3"
 CORE_IMAGE_EXTRA_INSTALL += "python3-opencv v4l-utils"
 
-# adding tcpdump for general network troubleshooting
-CORE_IMAGE_EXTRA_INSTALL += "tcpdump"
+# adding tcpdump and netcat for general network troubleshooting
+CORE_IMAGE_EXTRA_INSTALL += "tcpdump netcat"

--- a/meta-aesd/recipes-aesd-assignments/opencvdemo/opencvdemo_git.bb
+++ b/meta-aesd/recipes-aesd-assignments/opencvdemo/opencvdemo_git.bb
@@ -22,7 +22,6 @@ inherit pkgconfig cmake
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 opencvdemo ${D}${bindir}
-    install -m 0755 ${S}/acc-vid.sh ${D}${bindir}
 }
 
 # NOTE: the image could be made smaller by using the individual opencv depends.


### PR DESCRIPTION
The ac-cloudifier app is ready. This PR updates the app and dependencies on the Yocto repository, so that it can be run manually. SystemD services to automatically start the app are still needed.